### PR TITLE
docs: migliorare README per prima installazione

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,38 +4,43 @@
 
 A command line interface for interacting with our beloved 🐷 BOT.
 
-## Installation
+## Installazione
 
-### 0. Check for python
+### 0. Python
 
-This tool is based on **python 3.8** or higher, check that you have it.
+Controlla di avere installata una versione di Python 🐍 compatibile, cioè **3.8** o superiore.
+Per controllare esegui `python3 --version` nel terminale.
 
-### 1. Install with pip
+### 1. Installa il comando
 
-Install the cli with pip (Python package installer)
+Il comando si installa con *pip* il [Package Installer per Python](https://pypi.org/project/pip/).
 
 ```sh
 python3 -m pip install git+https://github.com/labmiriade/bot-cli.git
 ```
 
-### 2. _Optional_ add autocompletion
+### 2. _Opzionale_ Aggiungere l'autocompletamento
 
-Adding autocompletion is optional but highly recommended.
-Instruction varies between shells.
+Non è obbligatorio abilitare l'autocompletamento ma semplifica notevolmente la vita (ad esempio nell'inserimento
+dei nomi delle commesse).
 
-For **Bash**, add this to ~/.bashrc:
+La procedura consiste nell'aggiungere un comando all'avvio della shell: questo varia a seconda della
+shell che si utilizza ma per tutte consiste nel copiare il comando _eval_ qui sotto nel file eseguito
+all'avvio di una nuova sezione.
+
+Per **Bash**, aggiungi a _~/.bashrc_:
 
 ```sh
 eval "$(_BOT_COMPLETE=source_bash bot)"
 ```
 
-For **Zsh**, add this to ~/.zshrc:
+Per **Zsh**, aggiungi a _~/.zshrc_:
 
 ```sh
 eval "$(_BOT_COMPLETE=source_zsh bot)"
 ```
 
-For **Fish**, add this to ~/.config/fish/completions/foo-bar.fish:
+Per **Fish**, crea il file _~/.config/fish/completions/bot.fish_:
 
 ```sh
 eval (env _BOT_COMPLETE=source_fish bot)
@@ -43,14 +48,73 @@ eval (env _BOT_COMPLETE=source_fish bot)
 
 ## Getting Started
 
-Per iniziare digita `bot config` e inserisci il tuo username e la tua password.
+Per iniziare digita `bot config` e inserisci il tuo username (la mail aziendale), la tua password
+e la sede preferita (potrai impostarla per ogni rapportino, questo sarà il default).
 
-### Common Commands
+### Ottenere la password
+
+Se hai sempre fatto il login con Google è probabile che tu non conosca la password del tuo utente:
+questa è la procedura per ottenerla.
+
+1. Vai nella [homepage di bot](https://bot.miriade.it) e seleziona "Password dimenticata".
+
+2. Compila i campi username e password
+
+3. Se ti viene chiesto di rispondere alla domanda di sicurezza, rispondi. Se non ricordi la risposta
+la puoi leggere accedendo a BOT, cliccando sull'icona in alto a dx, andando in Impostazioni Account >
+Password.
+
+4. Controlla la tua casella email e segui le istruzioni per impostare una nuova password.
+
+### Comandi più comuni
 
 I comandi più comuni sono quelli in `bot rapp`, come **add**, **ls**, **missing**.
+
+Ma è molto importante conoscere anche `bot settings svuota-cache`, per svuotare la cache e assicurarsi
+di ricevere le commesse appena aggiunte.
+
+#### Rapportini
+
+Per interagire con i rapportini puoi iniziare con:
+
+```sh
+bot rapp ls
+```
+
+che inizierà a stampare a ritroso i rapportini inseriti negli ultimi 7 giorni.
+
+Puoi usare l'opzione `--data 03-03-2021` per controllare i rapportini di una data specifica
+e l'opzione `--count <numero-giorni>` per decidere quanti giorni a ritroso dalla data selezionata
+vanno mostrati.
+
+Per visualizzare le date per cui manca da inserire i rapportini puoi utilizzare:
+
+```sh
+bot rapp missing
+```
+
+Mentre per inserire un rapportino puoi digitare:
+
+```sh
+bot rapp add COMMESSA ATTIVITÀ
+```
+
+non è necessario inserire la commessa o l'attività se si è abilitato l'autocompletamento, basta utilizzare il tasto
+_<tab>_ per far comparire una lista di opzioni.
+
+Verranno chieste dal comando le opzioni come data, ore da inserire, descrizione, note e sede ma tutte queste sono
+opzioni che possono essere specificate nel comando iniziale:
+
+```sh
+bot rapp add 81_MIR_FORMAZIONE 24_Formazione_effettuata --sede 2 --ore 4
+```
+
+fa sì che le informazioni su sede e ore non vengano chieste.
+
+Prima di salvare il rapportino è possibile premere `f` per modificare i _flag_ (trasferta, prepagato, fatturare,
+straordinario), altrimenti premere `y` per confermare.
 
 ## Contribuire
 
 Sarebbe fantastico se volessi contribuire con l'introduzione di nuove feature o sistemare qualche problema ❤️.
 Leggi [CONTRIBUTING.md](/CONTRIBUTING.md) per ulteriori informazioni su come fare.
-


### PR DESCRIPTION
## To Do
- [x] valutare se convertire l'intero README in italiano
- [x] **fix** comandi per autocompletamento cambiando `foo-bar` in `bot` come da [documentazione](https://click.palletsprojects.com/en/7.x/bashcomplete/#activation)
- [x] aggiungere informazioni su come ottenere la password da BOT
- [x] aggiungere al comando `bot config` il link alla sezione ☝🏾 del README che spiega come ottenere la password da BOT
- [x] specificare meglio come interagire con i rapportini e le principali funzioni
- [x] aggiungere template per issue e pr

closes #2 